### PR TITLE
Feature done. Prints error if BTLE is not supported on the device

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -25,4 +25,6 @@
     </platform>
     <engine name="android" spec="~5.1.1" />
     <plugin name="cordova-plugin-ble-central" spec="~1.0.6" />
+    <plugin name="cordova-plugin-bluetooth-status" spec="~1.0.4" />
+    <plugin name="cordova-plugin-dialogs" spec="~1.2.1" />
 </widget>

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -52,8 +52,22 @@ var app = {
 		btnRefresh.addEventListener('touchstart', this.refreshSensorTagList, false);
         disconnectButton.addEventListener('touchstart', this.disconnect, false);        
     },
-	// Scan for SensorTags, after startup
     onDeviceReady: function() {
+        //check if the device supports Bluetooth Low Energy
+        try {
+            //Android: will only work if the BluetoothManager class is present. So Android 4.3 is required as earlier versions dont have this class
+            cordova.plugins.BluetoothStatus.initPlugin();
+            if(!BluetoothStatus.hasBTLE){
+                //The device has sufficient Android version but does not have BTLE hardware
+                navigator.notification.alert("Sorry. Your device does not support BTLE!", function(){navigator.app.exitApp();});
+                return;
+            }
+        }catch(e){
+            //BluetoothStatus was undefined because initPlugin did not work -> probably the phone does not have BT
+            navigator.notification.alert("Sorry. Your device does not support BTLE!", function(){navigator.app.exitApp();});
+            return;
+        }
+        // Scan for SensorTags, after startup
         app.refreshSensorTagList();
     },
 	// Update the List of Devices
@@ -130,6 +144,7 @@ var app = {
     onError: function(reason) {
         alert("ERROR: " + reason);
     }
+    
 };
 
 app.initialize();


### PR DESCRIPTION
- added cordova-plugin-bluetooth-status to plugins
- added cordova-plugin-dialogs to plugins
- uses native dialogs for error message
