### PR TITLE
Feature done. Prints error if BTLE is not supported on the device

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -55,4 +55,6 @@
         </platform>
         <engine name="android" spec="~5.1.1" />
         <plugin name="cordova-plugin-ble-central" spec="~1.0.6" />
+    <plugin name="cordova-plugin-bluetooth-status" spec="~1.0.4" />
+    <plugin name="cordova-plugin-dialogs" spec="~1.2.1" />
 </widget>

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -52,9 +52,22 @@ var app = {
 		btnRefresh.addEventListener('touchstart', this.refreshSensorTagList, false);
         disconnectButton.addEventListener('touchstart', this.disconnect, false);        
     },
-	// Scan for SensorTags, after startup
     onDeviceReady: function() {
-        app.refreshSensorTagList();
+        //check if the device supports Bluetooth Low Energy
+        //Android: initPlugin sets the values of BluetoothStatus. It will fail if the BluetoothManager class is not present
+        //Android 4.3 is required as earlier versions dont have this class. Also for BTLE support at least Android 4.3 is needed
+        cordova.plugins.BluetoothStatus.initPlugin();
+        //dirty hack: wait for 1 second as otherwise the hasBTLE will not be set. Moving this into another event also wont work
+        setTimeout(function() {
+            if(!cordova.plugins.BluetoothStatus.hasBTLE){
+                //as hasBTLE defaults to false we can still use it even if initPlugin fails,
+                //which should only happen if the device has an Android version below 4.3
+                navigator.notification.alert("Sorry. Your device does not support BTLE!", function(){navigator.app.exitApp();});
+                return;
+            }
+        }, 1000);
+        // Scan for SensorTags, after startup
+        //app.refreshSensorTagList();
     },
 	// Update the List of Devices
     refreshSensorTagList: function() {
@@ -130,6 +143,7 @@ var app = {
     onError: function(reason) {
         alert("ERROR: " + reason);
     }
+    
 };
 
 app.initialize();


### PR DESCRIPTION
- added cordova-plugin-bluetooth-status to plugins
- added cordova-plugin-dialogs to plugins
- uses native dialogs for error message
- uses dirty hack, waits for 1 second after initPlugin();

Should work now but somebody with BTLE enabled device should test it.
