### PR TITLE
Fix issue#59

### DIFF
--- a/tests/unit-tests/SettingsCtrl.tests.js
+++ b/tests/unit-tests/SettingsCtrl.tests.js
@@ -60,6 +60,28 @@ describe('SettingsCtrl:', function() {
       expect($scope.settings.currentVolumeProfile).toBe(JSON.stringify($scope.settings.volumeProfiles[1]));
     });
 
+	it('should deselect volume profiles', function() {
+		muteHelper(false);
+		$scope.settings.currentVolumeProfile = JSON.stringify($scope.settings.volumeProfiles[1]);
+		$scope.changeVolumeProfile();
+		//when muting now no profile should be selected anymore
+		muteHelper(true);
+		for(var i = 0; i<$scope.settings.volumeProfiles.length; i++){
+			JSON.stringify($scope.settings.volumeProfiles[1])
+			expect($scope.settings.currentVolumeProfile).not.toBe(JSON.stringify($scope.settings.volumeProfiles[i]));
+		}
+	});
+
+	it('should reselect volume profiles', function() {
+		muteHelper(false);
+		$scope.settings.currentVolumeProfile = JSON.stringify($scope.settings.volumeProfiles[1]);
+		$scope.changeVolumeProfile();
+		muteHelper(true);
+		//when unmuting now the profile should be selected again
+		muteHelper(false);
+		expect($scope.settings.currentVolumeProfile).toBe(JSON.stringify($scope.settings.volumeProfiles[1]));
+	});
+
     it('should unmute on volumeChange', function() {
       muteHelper(true);
       expect($scope.settings.mute).toBe(true);

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -558,6 +558,7 @@ angular.module('app.controllers', [])
 
         $scope.changeVolumeProfile = function() {
             $scope.settings.volume = JSON.parse($scope.settings.currentVolumeProfile).volume;
+			$scope.settings.mute = false;
             $scope.update();
         }
 
@@ -565,9 +566,12 @@ angular.module('app.controllers', [])
         $scope.muteToggle = function() {
             if (settings.settings.mute) {
                 settings.settings.volBeforeMute = settings.settings.volume;
+				settings.settings.volProfileBeforeMute = settings.settings.currentVolumeProfile;
                 settings.settings.volume = parseInt(0);
+				$scope.settings.currentVolumeProfile = false; //deselects any volume profile
             } else {
                 settings.settings.volume = parseInt(settings.settings.volBeforeMute);
+				settings.settings.currentVolumeProfile = settings.settings.volProfileBeforeMute;
             }
             //persist settings
             $scope.update();

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -6,9 +6,9 @@ angular.module('app.services', [])
         // minCompatibleSettingsVersion they will be cleared.
         // REMEMBER: increase minCompatibleSettingsversion and settings-version in the
         // settings-Object if you change the settings object!
-        var minCompatibleSettingsVersion = 2;
+        var minCompatibleSettingsVersion = 3;
         var settings = {
-          "settings-version": 2,
+          "settings-version": 3,
            "reconnect": false,
            "duration": 5,
            "volume": 50,
@@ -19,7 +19,8 @@ angular.module('app.services', [])
            ],
            "currentVolumeProfile": false,
            "mute": false,
-           "volBeforeMute": 50
+           "volBeforeMute": 50,
+		   "volProfileBeforeMute": false
          };
 
         var storedSettingsVersion = JSON.parse(localStorage.getItem("settings-version"))

--- a/www/templates/tab-settings.html
+++ b/www/templates/tab-settings.html
@@ -1,10 +1,12 @@
 <ion-view view-title="Settings">
   <ion-content class="padding">
-    <h1>Settings</h1>
+      <h1>Settings</h1>
 
-      <ion-toggle ng-model="settings.reconnect" ng-change="update()" toggle-class="toggle-calm">Automatic Reconnect</ion-toggle>
-
-	  <div class="item">
+	  <ion-list>
+		<div class="item item-divider">
+            Automatic Reconnection
+        </div>
+		<ion-toggle ng-model="settings.reconnect" ng-change="update()" toggle-class="toggle-calm">Automatic Reconnect</ion-toggle>
 	  	<div class="item item-divider">
             Scan Duration
         </div>
@@ -17,8 +19,6 @@
 																			 translate: durationSliderLabel, hideLimitLabels: true}"></rzslider>
 		  <i class="icon ion-clock"></i>
 		</div>
-	  </div>
-      <div class="item">
         <div class="item range">
           <i class="icon ion-volume-low"></i>
             <rzslider rz-slider-model="settings.volume" rz-slider-options="{floor: 0, ceil: 100, onChange: changedVolume,
@@ -26,7 +26,7 @@
           <i class="icon ion-volume-high"></i>
         </div>
         <ion-toggle ng-model="settings.mute" ng-change="muteToggle()" toggle-class="toggle-calm">Mute</ion-toggle>
-        <ion-list class="list list-inset" ng-show="settings.volumeProfiles.length > 0 && !settings.mute">
+        <ion-list ng-show="settings.volumeProfiles.length > 0 && !settings.mute">
           <div class="item item-divider">
             Volume Profiles:
           </div>
@@ -41,7 +41,7 @@
                {{ volumeProfile.name }}
           </ion-radio>
         </ion-list>
-      </div>
+      </ion-list>
 
   </ion-content>
 </ion-view>

--- a/www/templates/tab-settings.html
+++ b/www/templates/tab-settings.html
@@ -26,7 +26,7 @@
           <i class="icon ion-volume-high"></i>
         </div>
         <ion-toggle ng-model="settings.mute" ng-change="muteToggle()" toggle-class="toggle-calm">Mute</ion-toggle>
-        <ion-list ng-show="settings.volumeProfiles.length > 0 && !settings.mute">
+        <ion-list ng-show="settings.volumeProfiles.length > 0">
           <div class="item item-divider">
             Volume Profiles:
           </div>


### PR DESCRIPTION
Mute button in landscape mode is properly displayed:
- put all elements in one list instead of having two lists. I also added a divider to automatic reconnection
  --> these two changes fix the issue

In Addition: changed volume profile behaviour: (I did that because on small displays the settings view makes a not so nice "jump" because the profiles disappeared)
- when muting volume profiles now stay visible
- the only get deselected then
- if you select a profile while on mute it is unmuted
- added tests for it
