### PR TITLE
Fix travis-ci build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ services:
         docker
 android:
         components:
-                - build-tools-23.0.3  # Specify your build tools verison
+                - build-tools-23.0.3  # Specify your build tools version
                 - android-23  # Android Platform Target
 env: # Envirement Variables
+        - TRAVIS_NODE_VERSION="v5.6.0"
 global:
 before_install:
         # Commands to excecute before install
@@ -19,9 +20,11 @@ before_install:
 install:
         # Specify what and how to install
         - echo "Install stage"
-        - curl --silent --location https://deb.nodesource.com/setup | sudo bash -
-        - sudo apt-get install -y nodejs inkscape
-        - sudo npm install -g cordova ionic bower gulp cordova-icon
+        # Install the correct node version using nvm.
+        # see: http://austinpray.com/ops/2015/09/20/change-travis-node-version.html
+        - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
+        - sudo apt-get install -y inkscape
+        - npm install -g cordova ionic bower gulp cordova-icon
         - npm i  # for installing gulp and other stuff
         - ionic state restore
         - ionic prepare

--- a/docs/ProjectTimeline.md
+++ b/docs/ProjectTimeline.md
@@ -189,3 +189,8 @@ as well:
 - use `angular.$apply()` to refresh angular bindings in non-angular events like
 `setTimeout()`. See [this](http://jimhoskins.com/2012/12/17/angularjs-and-apply.html) for
 further information.
+
+- errors during travis-ci build with non-sense error message
+  - see http://stackoverflow.com/questions/21053657/how-to-run-travis-ci-locally to
+  reproduce locally
+  - add a `--verbose`-flag to commands that fail (e.g. `cordova prepare --verbose`)


### PR DESCRIPTION
Due to an old version of nodejs that was used by the old
.travis.yml script errors appeared during travis build
(our nodejs provider changed its version).

Now nvm is used for easy node version selection.
Node v5.6.0 is used for the build.
