### PR TITLE
Disable Landscape Rotation

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -21,6 +21,7 @@
     <preference name="android-targetSdkVersion" value="23" />
     <preference name="BackupWebStorage" value="none" />
     <preference name="SplashScreen" value="none" />
+    <preference name="orientation" value="portrait" />
     <feature name="StatusBar">
         <param name="ios-package" onload="true" value="CDVStatusBar" />
     </feature>


### PR DESCRIPTION
When the auto-rotation in the phone activated, the app will stay in portrait mode eventhough the phone is turned to landscape mode
